### PR TITLE
Corrigir acesso ao formulário de edição para gestores

### DIFF
--- a/app/Http/Controllers/DemandaController.php
+++ b/app/Http/Controllers/DemandaController.php
@@ -87,11 +87,44 @@ class DemandaController extends Controller
      * Exibir os detalhes de uma demanda específica.
      * Esta função substitui sua API /api/demanda/{id}.
      */
-    public function show(Demanda $demanda)
+    public function show(Request $request, Demanda $demanda)
     {
+        $user = $request->user();
+        
+        // Verificação de autorização baseada no perfil do usuário
+        if ($user->perfil === 'usuário') {
+            // Usuários só podem ver demandas onde são solicitante ou executor
+            if ($demanda->solicitante_id !== $user->id && $demanda->executor_id !== $user->id) {
+                return response()->json(['error' => 'Não autorizado para visualizar esta demanda.'], 403);
+            }
+        } elseif ($user->perfil === 'gestor') {
+            // Gestores só podem ver demandas do seu grupo
+            $demanda->load('solicitante:grupo_id', 'executor:grupo_id');
+            
+            // Verifica se o solicitante ou executor pertence ao grupo do gestor
+            $solicitanteDoGrupo = $demanda->solicitante->grupo_id === $user->grupo_id;
+            $executorDoGrupo = $demanda->executor && $demanda->executor->grupo_id === $user->grupo_id;
+            
+            // Log para debug (remover em produção)
+            \Log::info('Autorização Gestor', [
+                'user_id' => $user->id,
+                'user_grupo_id' => $user->grupo_id,
+                'demanda_id' => $demanda->numero_demanda,
+                'solicitante_grupo_id' => $demanda->solicitante->grupo_id,
+                'executor_grupo_id' => $demanda->executor ? $demanda->executor->grupo_id : null,
+                'solicitante_do_grupo' => $solicitanteDoGrupo,
+                'executor_do_grupo' => $executorDoGrupo
+            ]);
+            
+            if (!$solicitanteDoGrupo && !$executorDoGrupo) {
+                return response()->json(['error' => 'Não autorizado para visualizar esta demanda.'], 403);
+            }
+        }
+        // Administradores podem ver todas as demandas
+        
         // Graças ao Route-Model Binding, o Laravel já encontrou a demanda pelo ID na URL.
         // Apenas carregamos os relacionamentos para incluir na resposta.
-        $demanda->load('solicitante:id,nome', 'executor:id,nome', 'atualizacoes.usuario:id,nome');
+        $demanda->load('solicitante:id,nome,grupo_id', 'executor:id,nome,grupo_id', 'atualizacoes.usuario:id,nome');
 
         return response()->json([
             'demanda' => $demanda,
@@ -106,6 +139,39 @@ class DemandaController extends Controller
      */
     public function update(Request $request, Demanda $demanda)
     {
+        $user = $request->user();
+        
+        // Verificação de autorização baseada no perfil do usuário
+        if ($user->perfil === 'usuário') {
+            // Usuários só podem editar demandas onde são solicitante ou executor
+            if ($demanda->solicitante_id !== $user->id && $demanda->executor_id !== $user->id) {
+                return response()->json(['error' => 'Não autorizado para editar esta demanda.'], 403);
+            }
+        } elseif ($user->perfil === 'gestor') {
+            // Gestores só podem editar demandas do seu grupo
+            $demanda->load('solicitante:grupo_id', 'executor:grupo_id');
+            
+            // Verifica se o solicitante ou executor pertence ao grupo do gestor
+            $solicitanteDoGrupo = $demanda->solicitante->grupo_id === $user->grupo_id;
+            $executorDoGrupo = $demanda->executor && $demanda->executor->grupo_id === $user->grupo_id;
+            
+            // Log para debug (remover em produção)
+            \Log::info('Autorização Gestor Update', [
+                'user_id' => $user->id,
+                'user_grupo_id' => $user->grupo_id,
+                'demanda_id' => $demanda->numero_demanda,
+                'solicitante_grupo_id' => $demanda->solicitante->grupo_id,
+                'executor_grupo_id' => $demanda->executor ? $demanda->executor->grupo_id : null,
+                'solicitante_do_grupo' => $solicitanteDoGrupo,
+                'executor_do_grupo' => $executorDoGrupo
+            ]);
+            
+            if (!$solicitanteDoGrupo && !$executorDoGrupo) {
+                return response()->json(['error' => 'Não autorizado para editar esta demanda.'], 403);
+            }
+        }
+        // Administradores podem editar todas as demandas
+        
         // Validação expandida para todos os campos do formulário de edição
         $validatedData = $request->validate([
             'tipo' => 'required|string|max:100',

--- a/resources/views/demanda-form-edit.blade.php
+++ b/resources/views/demanda-form-edit.blade.php
@@ -162,6 +162,14 @@
                 window.location.href = '/login';
                 return;
             }
+            if (demandResponse.status === 403) {
+                const errorData = await demandResponse.json();
+                throw new Error(errorData.error || 'Não autorizado para visualizar esta demanda.');
+            }
+            if (usersResponse.status === 403) {
+                const errorData = await usersResponse.json();
+                throw new Error(errorData.error || 'Não autorizado para acessar usuários.');
+            }
             if (!demandResponse.ok) throw new Error(`Erro ao buscar demanda: ${demandResponse.statusText}`);
             if (!usersResponse.ok) throw new Error(`Erro ao buscar usuários: ${usersResponse.statusText}`);
 
@@ -220,6 +228,8 @@
                 formMessageArea.textContent = 'Demanda atualizada com sucesso!';
                 formMessageArea.style.color = 'green';
                 modal.style.display = 'none';
+            } else if (response.status === 403) {
+                throw new Error(responseData.error || 'Não autorizado para editar esta demanda.');
             } else {
                 let errorMsg = responseData.error || (responseData.errors ? Object.values(responseData.errors).flat().join(' ') : `Erro: ${response.statusText}`);
                 throw new Error(errorMsg);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement authorization logic for demand viewing and editing, and enhance frontend error handling to fix access issues for 'Gestor' users.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, 'Gestor' users were unable to open the demand edit form, even for demands they should have access to. This PR adds robust authorization checks in `DemandaController`'s `show` and `update` methods, ensuring users can only access/modify demands based on their profile ('usuário', 'gestor', 'admin') and group affiliation. Frontend error handling in `demanda-form-edit.blade.php` was also improved to display specific 403 (Forbidden) messages from the backend, providing clearer feedback to the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c03f6db-9981-4285-810d-f524a9425261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c03f6db-9981-4285-810d-f524a9425261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>